### PR TITLE
Fix tile consistency

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -27,20 +27,6 @@ After completing the Login section, use the other links to go directly to one of
 
 <Column colLg={4} colMd={4} noGutterMdLeft>
 <ArticleCard
-    color="dark"
-    subTitle="Automation with the Public Cloud"
-    title="Want to learn how to automate infrastructure management in Public clouds?"
-    href="/tutorials/ibmcloud"
-    actionIcon="arrowRight"
-    >
-
-![](images/public-cloud.jpg)
-
-</ArticleCard>
-</Column>
-
-<Column colLg={4} colMd={4} noGutterMdLeft>
-<ArticleCard
     color="white"
     subTitle="Automation with VMware"
     title="Want to learn how to automate infrastructure management in VMWare vSphere?"
@@ -52,6 +38,20 @@ After completing the Login section, use the other links to go directly to one of
 
 </ArticleCard>
 
+</Column>
+
+<Column colLg={4} colMd={4} noGutterMdLeft>
+<ArticleCard
+    color="dark"
+    subTitle="Automation with the Public Cloud"
+    title="Want to learn how to automate infrastructure management in Public clouds?"
+    href="/tutorials/ibmcloud"
+    actionIcon="arrowRight"
+    >
+
+![](images/public-cloud.jpg)
+
+</ArticleCard>
 </Column>
 
 <Column colLg={4} colMd={4} noGutterMdLeft>

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -27,7 +27,7 @@ After completing the Login section, use the other links to go directly to one of
 
 <Column colLg={4} colMd={4} noGutterMdLeft>
 <ArticleCard
-    color="white"
+    color="dark"
     subTitle="Automation with VMware"
     title="Want to learn how to automate infrastructure management in VMWare vSphere?"
     href="/tutorials/vmware"


### PR DESCRIPTION
The left nav has vmware first, then IBM cloud, so this change makes the
ordering consistent.  The other option is to change the left nav
ordering.

@b1stern I wasn't sure which one you wanted student to do first or second, so I followed the left nav ordering for this PR.